### PR TITLE
Fix'd multiple-of-64 workaround.

### DIFF
--- a/filter/index-braille.sh.in
+++ b/filter/index-braille.sh.in
@@ -21,14 +21,13 @@ fi
 
 # Check for required utilities, otherwise disable file-length patching (since
 # if till fail).
-WC=`which wc`
-AWK=`which awk`
+STAT=`which stat`
 EXPR=`which expr`
-if test -z "${WC}" -o -z "${AWK}" -o -z "${EXPR}"
+if test -z "${STAT}" -o -z "${EXPR}"
 then
 	# Some utility is missing, inform user.
 	echo "INFO: Utilities missing, file-length patching is disabled." >> /dev/stderr
-	echo "INFO: WC='${WC}', AWK='${AWK}', EXPR='${EXPR}'." >> /dev/stderr
+	echo "INFO: STAT='${STAT}', EXPR='${EXPR}'." >> /dev/stderr
 	PATCH_FILE_LENGTH=0
 fi
 
@@ -36,11 +35,13 @@ fi
 if test $PATCH_FILE_LENGTH -ne 0
 then
 	# Patch the file lenght, if required.
-	FILE_LENGTH=`wc -c $FILENAME|awk '{print $1}'`
-	if test ! -z $FILE_LENGTH
+	FILE_LENGTH=`$STAT -c %s "${FILENAME}"`
+	if test -z $FILE_LENGTH
 	then
 		echo "INFO: Unable to read file-length, file-length patching is disabled." >> /dev/stderr
 		PATCH_FILE_LENGTH=0
+    else
+        echo "DEBUG: File-length $FILE_LENGTH" >> /dev/stderr
 	fi
 fi
 
@@ -60,7 +61,7 @@ do
 	if test $PATCH_FILE_LENGTH -ne 0
 	then
 		# We sent FILE_LENGTH + SUB-character.
-		TRANSFERED_BYTES="${TRANSFERED_BYTES} + ${FILE_LENGTH} + 1"
+        TRANSFERED_BYTES=`$EXPR $TRANSFERED_BYTES + $FILE_LENGTH + 1`
 	fi
 
 	# Decrease COPIES by one, if expr doesn't exists, we don't support
@@ -68,6 +69,8 @@ do
 	test -z "${EXPR}" && break
 	COPIES=`$EXPR $COPIES - 1`
 done
+
+echo "DEBUG: Transfer-length (unpatched): $FILE_LENGTH" >> /dev/stderr
 
 # Check the length of the transfer, if the lenght of the transfer is a
 # multiple of 64, add an extra SUB character. This is due to the kernel
@@ -83,13 +86,12 @@ done
 # Patch the transfer, if enabled and required.
 if test $PATCH_FILE_LENGTH -ne 0
 then
-	TRANSFERED_BYTES=`$EXPR $TRANSFERED_BYTES`
-	TRANSFERED_BYTES_MOD64=`$EXPR $FILE_LENGTH % 64`
+	TRANSFERED_BYTES_MOD64=`$EXPR $TRANSFERED_BYTES % 64`
 	if test $TRANSFERED_BYTES_MOD64 -eq 0
 	then
 		# Extra ASCII sub to ensure that the transfer length module 64
 		# is not 0.
-		echo "INFO: Patching file to avoid transfer length modulo-64 bug (length was $FILE_LENGTH)." >> /dev/stderr
+		echo "INFO: Patching print-data to avoid transfer length modulo-64 bug (length was $TRANSFERED_BYTES)." >> /dev/stderr
 		printf "\032"
 	fi
 fi


### PR DESCRIPTION
This was working for the index-direct-braille filter, but broken in
the index-braille.sh filter.