### PR TITLE
Avoid detecting all txt files as application/x-idx-doc

### DIFF
--- a/mime/indexbraille.types
+++ b/mime/indexbraille.types
@@ -1,6 +1,6 @@
 ################################################################################
 # Index Braille MIME-types handled by the printer.
-application/x-idx-doc	txt string(0,<1b44>)
+application/x-idx-doc	txt + string(0,<1b44>)
 application/x-idx-fw	ibe string(0,<1b74>)
 
 ################################################################################


### PR DESCRIPTION
All .txt files were previously detected as application/x-idx-doc MIME type, thus basically breaking printing them.

Whitespaces in MIME files mean OR. We need to use + to make it AND, so that only .txt files that have the 1b44 marker get recognized as application/x-idx-doc.